### PR TITLE
Remove commented-out code in homekit_controller sensor

### DIFF
--- a/homeassistant/components/homekit_controller/sensor.py
+++ b/homeassistant/components/homekit_controller/sensor.py
@@ -522,7 +522,6 @@ class HomeKitBatterySensor(HomeKitSensor):
     @property
     def is_charging(self) -> bool:
         """Return true if currently charging."""
-        # 0 = not charging
         # 1 = charging
         # 2 = not chargeable
         return self.service.value(CharacteristicsTypes.CHARGING_STATE) == 1


### PR DESCRIPTION
# Jammithri Kotapati

## Summary
     Removes unnecessary commented-out code from homekit_controller sensor component.

## Changes
     - Removed comment
     - 0 = not charging from is_charging method in homeassistant/components/
homekit_controller/sensor.py


## Impact
     - Improves code maintainability by removing dead code
     - No functional changes

     Fixes code smell: Maintainability (Medium priority)
- Syntax check passed
- Module structure intact
- Method logic unchanged